### PR TITLE
Correct depreciated to deprecated

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ import React from 'react';
 export default {
   title: 'BetterSoftwareLink',
   parameters: {
-    status: 'stable' // stable | beta | depreciated
+    status: 'stable' // stable | beta | deprecated
   },
 };
 

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -5,10 +5,10 @@ import { styled } from '@storybook/theming';
 
 const ADDON_ID = 'status';
 
-function statusBackground(status: 'beta' | 'stable' | 'depreciated') {
+function statusBackground(status: 'beta' | 'stable' | 'deprecated') {
   if (status === 'beta') return '#ec942c';
   if (status === 'stable') return '#339900';
-  if (status === 'depreciated') return '#f02c2c';
+  if (status === 'deprecated') return '#f02c2c';
   return '#666';
 }
 


### PR DESCRIPTION
This is a common mistake, but, as [this SO answer](https://stackoverflow.com/a/9208164/1390770) explains:

* __Deprecated__ means that it is still in use, but only for historical purposes and it will be removed probably in the next big release. It is recommended that you do not use deprecated functions or features - even if they are present in the current library for example.
* __Depreciated__ means the monetary value of something has decreased over time. E.g., cars typically depreciate in value.

This is obviously a breaking change