### PR TITLE
Adding link capability and merging, rather than overriding statuses.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "babel-plugin-require-context-hook": "1.0.0",
     "downlevel-dts": "0.5.0",
     "npmlog": "4.1.2",
+    "prettier": "^2.2.1",
     "shelljs": "0.8.4",
     "typescript": "3.9.5"
   },

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -1,65 +1,71 @@
-import React from 'react';
-import { addons, types } from '@storybook/addons';
-import { useStorybookApi } from '@storybook/api';
-import { styled } from '@storybook/theming';
+import React from "react";
+import { addons, types } from "@storybook/addons";
+import { useStorybookApi } from "@storybook/api";
+import { styled } from "@storybook/theming";
 
-const ADDON_ID = 'status';
+const ADDON_ID = "status";
 
 type tStatuses = {
-  [key: string]: string
-}
+  [key: string]: string;
+};
 
 const defaultStatuses: tStatuses = {
-  beta: '#ec942c',
-  stable: '#339900',
-  deprecated: '#f02c2c',
+  beta: "#ec942c",
+  stable: "#339900",
+  deprecated: "#f02c2c",
 };
 
 function statusBackground(status: string, statuses?: tStatuses) {
-  const availableStatuses = statuses || defaultStatuses;
-  return availableStatuses[status] || '#666';
+  const availableStatuses = { ...defaultStatuses, ...(statuses || {}) };
+  return availableStatuses[status] || "#666";
 }
 
 const StatusText = styled.span`
   align-items: center;
   align-self: center;
   background: ${(props: any) => statusBackground(props.status, props.statuses)};
-  border-radius: .25em;
+  border-radius: 0.25em;
   color: white;
   display: inline-flex;
   justify-content: center;
   line-height: 1;
-  padding: .25em .5em;
+  padding: 0.25em 0.5em;
   user-select: none;
 `;
 
+const StatusLink = styled.a`
+  color: inherit;
+  text-decoration: none;
+`;
 
 const Status = () => {
   const api = useStorybookApi();
   const story = api.getCurrentStoryData() as any;
   if (story) {
     const params = story.parameters;
-
-    if (params.status) {
+    const { status, statuses, statusLink } = params;
+    if (status) {
       return (
-        <StatusText 
-          status={params.status}
-          statuses={params.statuses}
-        >
-          {params.status}
+        <StatusText status={status} statuses={statuses}>
+          {statusLink ? (
+            <StatusLink href={statusLink}>{status}</StatusLink>
+          ) : (
+            status
+          )}
         </StatusText>
       );
     }
   }
 
   return null;
-}
+};
 
 addons.register(ADDON_ID, () => {
   addons.add(ADDON_ID, {
-    title: 'Status',
+    title: "Status",
     type: types.TOOL,
-    match: ({ viewMode }: { viewMode: string }) => viewMode === 'story' || viewMode === 'docs',
+    match: ({ viewMode }: { viewMode: string }) =>
+      viewMode === "story" || viewMode === "docs",
     render: () => {
       return <Status />;
     },


### PR DESCRIPTION
Also adds prettier and formats so contributors keep consistent style.

Basically, this makes it so that I can define only one (or additional) status and it merges so I don't have to define all the statuses again. It adds new prop, statusLink, that lets me add a url, thereby turning status label into a link, allowing me to link deprecated components to their replacement.