### PR TITLE
Added possibility for multiple status types

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,8 @@ export default {
   parameters: {
     status: {
       type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
+      // 
+      // 
       url: 'http://www.url.com/status', // will make the tag a link
       statuses: {...} // add custom statuses for this story here
     }
@@ -61,6 +63,16 @@ export default {
 export const defaultView = () => (
   <a href="https://makebetter.software">Make Better Software</a>
 );
+```
+
+For multiple statuses the type property also accepts array values. If not specifically set every status uses the same Url.
+
+**NOTE:** The status dot in the sidebar only shows the color of the first status.
+
+```jsonc
+status: {
+  type: ['beta', 'released', 'myCustomStatus', { name: 'stable', url: 'http://www.example.com' }]
+}
 ```
 
 **.mdx** (using addon-docs)

--- a/Readme.md
+++ b/Readme.md
@@ -52,8 +52,6 @@ export default {
   parameters: {
     status: {
       type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      // 
-      // 
       url: 'http://www.url.com/status', // will make the tag a link
       statuses: {...} // add custom statuses for this story here
     }
@@ -65,15 +63,16 @@ export const defaultView = () => (
 );
 ```
 
-For multiple statuses the type property also accepts array values. If not specifically set every status uses the same Url.
-
-**NOTE:** The status dot in the sidebar only shows the color of the first status.
+For multiple statuses `type` also accepts array values. If not specifically set every status uses `status.url` as the linked Url.
 
 ```jsonc
 status: {
-  type: ['beta', 'released', 'myCustomStatus', { name: 'stable', url: 'http://www.example.com' }]
+  type: ['beta', 'released', 'myCustomStatus', { name: 'stable', url: 'http://www.example.com' }],
+  // url, statuses ...
 }
 ```
+
+**NOTE:** The status dot in the sidebar only shows the color of the first status.
 
 **.mdx** (using addon-docs)
 

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
 import { addons, types } from '@storybook/addons';
+import { startCase } from 'lodash';
+import React from 'react';
 
-import Status from './components/StatusTag';
 import StatusDot from './components/StatusDot';
+import Status from './components/StatusTag';
 import { ADDON_ID } from './constants';
+import { defaultStatuses } from './defaults';
 
 import type { AddonParameters } from './types';
-import { defaultStatuses } from './defaults';
 
 type RenderLabelItem = {
   name: string;
@@ -40,7 +41,16 @@ addons.register(ADDON_ID, () => {
           ...(status.statuses || {}),
         };
 
-        const statusConfig = statusConfigMap[status.type];
+        let statusName: string = '';
+
+        if (Array.isArray(status.type)) {
+          const firstStatus = status.type?.[0];
+          statusName = typeof firstStatus === 'string' ? firstStatus : firstStatus.name;
+        } else {
+          statusName = status.type;
+        }
+
+        const statusConfig = statusConfigMap[statusName];
 
         if (!statusConfig) {
           return name;
@@ -53,7 +63,7 @@ addons.register(ADDON_ID, () => {
             {name}
             <StatusDot
               background={background}
-              title={`${status}: ${description}`}
+              title={`${startCase(statusName)}: ${description}`}
             />
           </>
         );

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,11 @@ export type StatusType =
   | 'releaseCandidate'
   | string;
 
+export type UrlStatusType = {
+  name: StatusType,
+  url: string;
+};
+
 export type CustomStatusType = {
   background?: string;
   color?: string;
@@ -16,7 +21,7 @@ export type CustomStatusTypes = {
 };
 
 export type AddonParameters = {
-  type?: StatusType;
+  type?: StatusType | (StatusType | UrlStatusType)[];
   statuses?: CustomStatusTypes;
   url?: string;
 };


### PR DESCRIPTION
I've added the ability to use multiple status types for a component.

This is in reference to issue https://github.com/etchteam/storybook-addon-status/issues/21

The following configs are valid:

```jsonc
// Does the same as the current behavior
parameters: {
  status: {
    type: 'beta',
    url: 'http://www.url.com/status',
  }
}

// Displays multiple badges (but only the dot of beta). All badges except for deprecated link to the same url
// If no "top level" url is specified only deprecated will be a link
parameters: {
  status: {
    type: ['beta', 'stable', 'released', { name: 'deprecated', url: 'http://example.com' } ],
    url: 'http://www.url.com/status',
  }
},
```

![image](https://user-images.githubusercontent.com/3532342/140906354-51969a33-fab0-4c08-9a63-cdb1b0bcb8a5.png)
