### PR TITLE
Added `version` to base configuration of addon

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,7 +69,25 @@ For multiple statuses `type` also accepts array values. If not specifically set 
 ```jsonc
 status: {
   type: ['beta', 'released', 'myCustomStatus', { name: 'stable', url: 'http://www.example.com' }],
-  // url, statuses ...
+  // url, version, statuses ...
+}
+```
+
+To include a `version` beside the `type` add the parameter as a string.
+
+```jsonc
+status: {
+  version: '1.2.5'
+  // type, url ...
+}
+```
+
+Also more complex `version`s are accepted.
+
+```jsonc
+status: {
+  version: '2.0.0-alpha.0'
+  // type, url ...
 }
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,7 @@ export default {
   parameters: {
     status: {
       type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
+      version: '1.2.5', // will be displayed between parentheses after the type
       url: 'http://www.url.com/status', // will make the tag a link
       statuses: {...} // add custom statuses for this story here
     }

--- a/src/components/StatusTag.tsx
+++ b/src/components/StatusTag.tsx
@@ -4,7 +4,7 @@ import { styled, css } from '@storybook/theming';
 import { startCase } from 'lodash';
 import { defaultStatuses, defaultBackground, defaultColor } from '../defaults';
 import { ADDON_PARAM_KEY } from '../constants';
-import { AddonParameters, CustomStatusType, StatusVersion } from '../types';
+import type { AddonParameters, CustomStatusType, StatusVersion } from '../types';
 
 const tagStyles = css`
   align-self: center;

--- a/src/components/StatusTag.tsx
+++ b/src/components/StatusTag.tsx
@@ -4,8 +4,7 @@ import { styled, css } from '@storybook/theming';
 import { startCase } from 'lodash';
 import { defaultStatuses, defaultBackground, defaultColor } from '../defaults';
 import { ADDON_PARAM_KEY } from '../constants';
-
-import type { AddonParameters, CustomStatusType } from '../types';
+import { AddonParameters, CustomStatusType } from '../types';
 
 const tagStyles = css`
   align-self: center;

--- a/src/components/StatusTag.tsx
+++ b/src/components/StatusTag.tsx
@@ -4,7 +4,7 @@ import { styled, css } from '@storybook/theming';
 import { startCase } from 'lodash';
 import { defaultStatuses, defaultBackground, defaultColor } from '../defaults';
 import { ADDON_PARAM_KEY } from '../constants';
-import { AddonParameters, CustomStatusType } from '../types';
+import { AddonParameters, CustomStatusType, StatusVersion } from '../types';
 
 const tagStyles = css`
   align-self: center;
@@ -48,7 +48,7 @@ const StatusTag = () => {
     ...(statuses || {}),
   };
 
-  let statusConfigs: { url?: string; label?: string, status?: CustomStatusType, version?: string }[];
+  let statusConfigs: { url?: string; label?: string, status?: CustomStatusType, version?: StatusVersion }[];
 
   if (Array.isArray(type)) {
     statusConfigs = type.map((t) => {

--- a/src/components/StatusTag.tsx
+++ b/src/components/StatusTag.tsx
@@ -38,7 +38,7 @@ const StatusTag = () => {
     return null;
   }
 
-  const { type, url, statuses } = parameters;
+  const { type, url, statuses, version } = parameters;
 
   if (!type) {
     return null;
@@ -49,7 +49,7 @@ const StatusTag = () => {
     ...(statuses || {}),
   };
 
-  let statusConfigs: { url?: string; label?: string, status?: CustomStatusType }[];
+  let statusConfigs: { url?: string; label?: string, status?: CustomStatusType, version?: string }[];
 
   if (Array.isArray(type)) {
     statusConfigs = type.map((t) => {
@@ -58,6 +58,7 @@ const StatusTag = () => {
           label: t,
           status: statusConfigMap[t],
           url,
+          version,
         };
       }
 
@@ -65,6 +66,7 @@ const StatusTag = () => {
         label: t.name,
         status: statusConfigMap[t.name],
         url: t.url,
+        version: t.version,
       };
     });
   } else {
@@ -73,6 +75,7 @@ const StatusTag = () => {
         label: type,
         status: statusConfigMap[type],
         url,
+        version,
       },
     ];
   }
@@ -95,6 +98,7 @@ const StatusTag = () => {
         };
 
         const label = startCase(statusConfig.label);
+        const version = statusConfig.version ? `(${statusConfig.version})` : ''
 
         return statusUrl ? (
           <LinkTag
@@ -103,11 +107,11 @@ const StatusTag = () => {
             title={description}
             href={statusUrl}
           >
-            {label}
+            {label} {version}
           </LinkTag>
         ) : (
           <TextTag key={statusConfig.label} style={style} title={description}>
-            {label}
+            {label} {version}
           </TextTag>
         );
       })}

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,11 @@ export type CustomStatusTypes = {
   [key: string]: CustomStatusType;
 };
 
+export type StatusVersion = string
+
 export type AddonParameters = {
   type?: StatusType | (StatusType | UrlStatusType)[];
   statuses?: CustomStatusTypes;
   url?: string;
+  version? : StatusVersion
 };


### PR DESCRIPTION
The current status configuration is based on these three parameters:

```
    status: {
      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
      url: 'http://www.url.com/status', // will make the tag a link
      statuses: {...} // add custom statuses for this story here
    }
```

This PR is intended to change it to four:

```
    status: {
      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
      version: '1.2.5', // will be displayed between parentheses after the type
      url: 'http://www.url.com/status', // will make the tag a link
      statuses: {...} // add custom statuses for this story here
    }
```

With the goal to have `version` displayed between parentheses after the `type` label.