### PR TITLE
Handled differently default `color` and `backgroundColor`, if referred to one of the predefined types

### DIFF
--- a/src/components/StatusDot.tsx
+++ b/src/components/StatusDot.tsx
@@ -1,13 +1,14 @@
 import { styled } from '@storybook/theming';
-import { defaultBackground } from '../defaults';
+import { defaultStatuses, defaultBackground } from '../defaults';
 
 type StatusDotProps = {
+  type?: string
   background?: string;
 };
 
 const StatusDot = styled.span<StatusDotProps>`
   align-self: center;
-  background-color: ${({ background }) => background ?? defaultBackground};
+  background-color: ${({ background }) => background ?? (defaultStatuses[type] ? defaultStatuses[type].background : defaultBackground) };
   border-radius: 100%;
   height: 6px;
   margin-left: 0.5em;

--- a/src/components/StatusTag.tsx
+++ b/src/components/StatusTag.tsx
@@ -88,13 +88,14 @@ const StatusTag = () => {
       {statusConfigs.map((statusConfig) => {
         const { background, color, description } = statusConfig.status;
         const statusUrl = statusConfig.url;
+        const label = startCase(statusConfig.label);
 
         const style: React.CSSProperties = {
-          color: color ?? defaultColor,
-          backgroundColor: background ?? defaultBackground,
+          color: color ??
+            (defaultStatuses[label] ? defaultStatuses[label].color : defaultColor),
+          backgroundColor: background ??
+            (defaultStatuses[label] ? defaultStatuses[label].background : defaultBackground),
         };
-
-        const label = startCase(statusConfig.label);
 
         return statusUrl ? (
           <LinkTag

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -62,6 +62,7 @@ addons.register(ADDON_ID, () => {
           <>
             {name}
             <StatusDot
+              type={statusName}
               background={background}
               title={`${startCase(statusName)}: ${description}`}
             />


### PR DESCRIPTION
Currently when `statuses` is set, redefining some extra values for one of the current types, then a different `color` and `background color` is set.

Now, since types contain a predefined `color` and `background color` in the constant `defaultStatuses` of `default.ts` file, in case they are not overwritten, they inherit the default values.

`defaultColor` and `defaultBackground` are used only for custom types.