### PR TITLE
Fix status dot never appearing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@etchteam/storybook-addon-status",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@etchteam/storybook-addon-status",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "MIT",
       "dependencies": {
         "@storybook/api": "^7.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etchteam/storybook-addon-status",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "Add component status to the storybook UI",
   "main": "dist/preset.js",
   "files": [

--- a/src/register.jsx
+++ b/src/register.jsx
@@ -7,7 +7,7 @@ import Status from './components/StatusTag';
 import { ADDON_ID, ADDON_PARAM_KEY } from './constants';
 import { defaultStatuses } from './defaults';
 
-addons.register(ADDON_ID, () => {
+addons.register(ADDON_ID, (api) => {
   addons.add(ADDON_ID, {
     title: 'Status',
     type: types.TOOL,
@@ -24,46 +24,51 @@ addons.register(ADDON_ID, () => {
   addons.setConfig({
     sidebar: {
       renderLabel: (item) => {
-        const { name, isLeaf, parameters } = item;
-        // item can be a Root | Group | Story
-        if (!isLeaf || !parameters || !parameters.status) {
+        const { name, isLeaf } = item;
+
+        try {
+          const status = api.getParameters(item.id, ADDON_PARAM_KEY);
+
+          // item can be a Root | Group | Story
+          if (!isLeaf || !status || !status?.type) {
+            return name;
+          }
+
+          const statusConfigMap = {
+            ...defaultStatuses,
+            ...(status.statuses || {}),
+          };
+
+          let statusName = '';
+
+          if (Array.isArray(status.type)) {
+            const firstStatus = status.type?.[0];
+            statusName = typeof firstStatus === 'string' ? firstStatus : firstStatus.name;
+          } else {
+            statusName = status.type;
+          }
+
+          const statusConfig = statusConfigMap[statusName];
+
+          if (!statusConfig) {
+            return name;
+          }
+
+          const { background, description } = statusConfig;
+
+          return (
+            <>
+              {name}
+              <StatusDot
+                type={statusName}
+                background={background}
+                title={`${startCase(statusName)}: ${description}`}
+              />
+            </>
+          );
+        } catch (error) {
           return name;
         }
-
-        const { status } = parameters;
-
-        const statusConfigMap = {
-          ...defaultStatuses,
-          ...(status.statuses || {}),
-        };
-
-        let statusName = '';
-
-        if (Array.isArray(status.type)) {
-          const firstStatus = status.type?.[0];
-          statusName = typeof firstStatus === 'string' ? firstStatus : firstStatus.name;
-        } else {
-          statusName = status.type;
-        }
-
-        const statusConfig = statusConfigMap[statusName];
-
-        if (!statusConfig) {
-          return name;
-        }
-
-        const { background, description } = statusConfig;
-
-        return (
-          <>
-            {name}
-            <StatusDot
-              type={statusName}
-              background={background}
-              title={`${startCase(statusName)}: ${description}`}
-            />
-          </>
-        );
       },
     },
   });


### PR DESCRIPTION
In storybook v7 we've stopped recieving the story's parameters inside the renderLabel `item` object.

I've tried using all the methods on the API to receive the parameters but none of them provide good results.

This PR contains a best effort which is to use the `getParameters` method to retrieve the stories parameters based on the `item.id`. Unfortunately this never loads in the parameters for the story correctly until the story has been loaded, so we only get dots after the story has been visited as shown in the attached.


https://github.com/etchteam/storybook-addon-status/assets/5038459/a7352ab6-8df1-4b68-8107-fd04b8fc29a1

Related https://github.com/etchteam/storybook-addon-status/issues/28
