### PR TITLE
Set statuses via storybook tags

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,13 @@
+import { addons } from "storybook/manager-api";
+
+addons.setConfig({
+  status: {
+    statuses: {
+      customStatus: {
+        background: '#0000ff',
+        color: '#ffffff',
+        description: 'This component is stable and released',
+      },
+    },
+  },
+});

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,3 +1,4 @@
+import { background } from "storybook/internal/theming";
 import { addons } from "storybook/manager-api";
 
 addons.setConfig({
@@ -9,5 +10,6 @@ addons.setConfig({
         description: 'This component is stable and released',
       },
     },
+    sidebarDots: 'multiple', // 'single' | 'multiple' | 'none'. 'single' is the default
   },
 });

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,4 +1,3 @@
-import { background } from "storybook/internal/theming";
 import { addons } from "storybook/manager-api";
 
 addons.setConfig({

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,14 +1,5 @@
 const preview = {
   parameters: {
-    status: {
-      statuses: {
-        customStatus: {
-          background: '#0000ff',
-          color: '#ffffff',
-          description: 'This component is stable and released',
-        },
-      },
-    },
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
       matchers: {

--- a/Readme.md
+++ b/Readme.md
@@ -22,25 +22,26 @@ export default {
 };
 ```
 
-In `preview.js` you can globally configure custom status configurations, or overwrite the built in "beta", "deprecated", "stable" & "releaseCandidate".
+In `manager.js` you can globally configure custom status configurations, or overwrite the built in "beta", "deprecated", "stable" & "releaseCandidate". You can also change how status dots will appear in the sidebar with the `sidebarDots` prop.
 
 ```js
-export default {
-  parameters: {
-    status: {
-      statuses: {
-        released: {
-          background: '#0000ff',
-          color: '#ffffff',
-          description: 'This component is stable and released',
-        },
+import { addons } from "storybook/manager-api";
+
+addons.setConfig({
+  status: {
+    statuses: {
+      released: {
+        background: '#0000ff',
+        color: '#ffffff',
+        description: 'This component is stable and released',
       },
     },
-  }
-};
+    sidebarDots: 'single', // 'single' | 'multiple' | 'none'. 'single' is the default
+  },
+});
 ```
 
-**NOTE:** Each key will be used as the label for the tag and will convert camelCase to words
+**NOTE:** Each key will be used as the label for the status and will convert camelCase to words
 
 ## Story Usage
 
@@ -65,7 +66,7 @@ export default {
 };
 ```
 
-This can be used for the built-in statuses, as well as any custom statuses defined in `preview.js`
+This can be used for the built-in statuses, as well as any custom statuses defined in `manager.js`. Only these tags will appear as statuses - if they are not built-in or have a definition in `manager.js`, they will be ignored by the addon. This means that status tags can be used alongside tags for other purposes.
 
 Using tags to define statuses means that stories can also be [filtered](https://storybook.js.org/docs/writing-stories/tags#filtering-by-custom-tags) by status.
 
@@ -87,7 +88,7 @@ export default {
 };
 ```
 
-`type` also accepts an object with `name` and `url` keys, or an array or strings and/or objects for multiple statuses.
+`type` also accepts an object with `name` and `url` keys, or an array of strings and/or objects for multiple statuses.
 
 If not specifically set, every status uses `status.url` as the linked Url.
 
@@ -110,7 +111,7 @@ export default {
 }
 ```
 
-Setting statuses via the story parameters allows more customisation on a story-by-story basis, but at the expense of sidebar filtering. Additionally, using this method means that the status dot in the sidebar only shows the color of the first status, and only for the story that is currently being viewed.
+Setting statuses via the story parameters allows more customisation on a story-by-story basis, but at the expense of sidebar filtering. Additionally, using this method means that the status dot(s) in the sidebar only shows for the story that is currently being viewed - this is a [known limitation](https://github.com/storybookjs/storybook/discussions/24022#discussioncomment-12737532) of the way Storybook works.
 
 ### Combined method
 
@@ -144,7 +145,7 @@ export default {
 };
 ```
 
-**NOTE:** The dot in the sidebar for a status with custom styles added in a particular story will only work while you are viewing that story. This is [known limitation](https://github.com/storybookjs/storybook/discussions/24022#discussioncomment-12737532) of the way Storybook works. We recommend [defining custom status styles globally](#configuration) in `preview.js` wherever possible instead.
+**NOTE:** The sidebar dot(s) for a status with custom styles added in a particular story will only work while you are viewing that story. This is a [known limitation](https://github.com/storybookjs/storybook/discussions/24022#discussioncomment-12737532) of the way Storybook works. We recommend [defining custom status styles globally](#configuration) in `preview.js` wherever possible instead.
 
 ## Migration guide
 

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ export default {
 };
 ```
 
-In `preview.js` you can globally configure custom status configurations, or overwrite the built in "beta", "deprecated", "stable" & "releaseCandidate"
+In `preview.js` you can globally configure custom status configurations, or overwrite the built in "beta", "deprecated", "stable" & "releaseCandidate".
 
 ```js
 export default {
@@ -40,11 +40,38 @@ export default {
 };
 ```
 
+**NOTE:** Each key will be used as the label for the tag and will convert camelCase to words
+
 ## Story Usage
 
-Then write your stories like this:
+There are two ways to add statuses to your stories:
 
-**.js**
+1. [Tags](#tags) (new, recommended)
+2. [Story parameters](#story-parameters) (legacy)
+
+You can also use [both methods together](#combined-method) to get the benefits of both at once.
+
+### Tags
+
+Storybook's built-in [tag system](https://storybook.js.org/docs/writing-stories/tags) can now be used to add statuses to your stories.
+
+Just add an array of status names to the `tags` property:
+
+```js
+
+export default {
+  title: 'BetterSoftwareLink',
+  tags: ['beta'],  // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate' | your own custom status
+};
+```
+
+This can be used for the built-in statuses, as well as any custom statuses defined in `preview.js`
+
+Using tags to define statuses means that stories can also be [filtered](https://storybook.js.org/docs/writing-stories/tags#filtering-by-custom-tags) by status.
+
+### Story parameters
+
+The alternative (legacy) way to add statuses to stories is to add them to the `status` property of the story parameters:
 
 ```js
 
@@ -53,20 +80,16 @@ export default {
   parameters: {
     status: {
       type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status', // will make the tag a link
-      statuses: {...} // add custom statuses for this story here
+      url: 'http://www.url.com/status', // Optional: will make the tag a link
+      statuses: {...} // Optional: add custom status configurations for this story here
     }
   },
 };
-
-export const Default = () => (
-  <a href="https://makebetter.software">Make Better Software</a>
-);
 ```
 
-For multiple statuses `type` also accepts array values.
+`type` also accepts an object with `name` and `url` keys, or an array or strings and/or objects for multiple statuses.
 
-If not specifically set every status uses `status.url` as the linked Url.
+If not specifically set, every status uses `status.url` as the linked Url.
 
 ```js
 export default {
@@ -78,31 +101,50 @@ export default {
         'myCustomStatus',
         {
           name: 'stable',
-          url: 'http://www.example.com'
+          url: 'http://www.url.com/stable'
         }
       ],
-      // url, statuses ..
+      url: 'http://www.url.com/status'
     },
   },
 }
 ```
 
-**NOTE:** The status dot in the sidebar only shows the color of the first status.
+Setting statuses via the story parameters allows more customisation on a story-by-story basis, but at the expense of sidebar filtering. Additionally, using this method means that the status dot in the sidebar only shows the color of the first status, and only for the story that is currently being viewed.
 
-**.mdx** (using addon-docs)
+### Combined method
+
+For the best of both worlds, tag and story parameter statuses can be used together. This gives you the ability to filter by status in the sidebar, see sidebar dots for all stories at once, and to customise statuses within a story.
+
+To do this, add all the statuses for the story to the `tags` array in the story definition. Then, add any statuses that need customisation (e.g. for a URL or custom style) to the story parameters' `status` property.
+
+Both sets of statuses will be combined and de-duplicated.
 
 ```js
-import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta
-  title="BetterSoftwareLink"
-  parameters={{ status: { type: 'beta' } }}
-/>
+export default {
+  title: 'BetterSoftwareLink',
+  tags: ['beta', 'customStoryStatus']
+  parameters: {
+    status: {
+      type: {
+        name: 'customStoryStatus',
+        url: 'http://www.url.com/custom',
+      },
+      url: 'http://www.url.com/status',
+      statuses: {
+        customStoryStatus: {
+          background: '#0000ff',
+          color: '#ffffff',
+          description: 'This is a custom status configuration for this story only',
+        }
+      }
+    },
+  },
+};
 ```
 
-You'll get a label injected in the top toolbar and the sidebar.
-
-**Note** the `type` will be used as label for tag and will convert camelCase to words
+**NOTE:** The dot in the sidebar for a status with custom styles added in a particular story will only work while you are viewing that story. This is [known limitation](https://github.com/storybookjs/storybook/discussions/24022#discussioncomment-12737532) of the way Storybook works. We recommend [defining custom status styles globally](#configuration) in `preview.js` wherever possible instead.
 
 ## Migration guide
 

--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,9 @@ addons.setConfig({
 });
 ```
 
-**NOTE:** Each key will be used as the label for the status and will convert camelCase to words
+**IMPORTANT:** The addon was previously configured using parameters in `preview.js`. This will still work as before, however newer features such as sidebar dot customisation are not available.
+
+**NOTE:** Each key will be used as the label for the status and will convert camelCase to words.
 
 ## Story Usage
 

--- a/src/components/StatusTag.jsx
+++ b/src/components/StatusTag.jsx
@@ -1,6 +1,6 @@
 import startCase from 'lodash/startCase';
 import React from 'react';
-import { useParameter, useStorybookApi } from 'storybook/manager-api';
+import { useParameter, useStorybookApi, addons } from 'storybook/manager-api';
 import { styled, css } from 'storybook/theming';
 
 import { ADDON_ID } from '../constants';
@@ -33,12 +33,12 @@ const StatusTag = () => {
   const tags = api.getCurrentStoryData()?.tags ?? [];
 
   const parameters = useParameter(ADDON_ID, null);
+  const customConfigs = addons.getConfig()?.[ADDON_ID]?.statuses;
 
   const statusConfigs = getStatusConfigs({
     tags,
     parameters,
-    // No need to pass customConfigs here as within a story, parameters.statuses
-    // already includes the custom statuses defined in preview.js.
+    customConfigs,
   });
 
   if (!statusConfigs?.length) {

--- a/src/components/StatusTag.jsx
+++ b/src/components/StatusTag.jsx
@@ -1,10 +1,11 @@
 import startCase from 'lodash/startCase';
 import React from 'react';
-import { useParameter } from 'storybook/manager-api';
+import { useParameter, useStorybookApi } from 'storybook/manager-api';
 import { styled, css } from 'storybook/theming';
 
 import { ADDON_ID } from '../constants';
 import { defaultStatuses, defaultBackground, defaultColor } from '../defaults';
+import { getStatusConfigs } from '../getStatusConfigs';
 
 const tagStyles = css`
   align-self: center;
@@ -28,52 +29,17 @@ const TextTag = styled.span`
 `;
 
 const StatusTag = () => {
+  const api = useStorybookApi();
+  const tags = api.getCurrentStoryData()?.tags ?? [];
+
   const parameters = useParameter(ADDON_ID, null);
 
-  if (parameters === null) {
-    return null;
-  }
-
-  const { type, url, statuses } = parameters;
-
-  if (!type) {
-    return null;
-  }
-
-  const statusConfigMap = {
-    ...defaultStatuses,
-    ...(statuses || {}),
-  };
-
-  let statusConfigs;
-
-  if (Array.isArray(type)) {
-    statusConfigs = type.map((t) => {
-      if (typeof t === 'string') {
-        return {
-          label: t,
-          status: statusConfigMap[t],
-          url,
-        };
-      }
-
-      return {
-        label: t.name,
-        status: statusConfigMap[t.name],
-        url: t.url,
-      };
-    });
-  } else {
-    statusConfigs = [
-      {
-        label: type,
-        status: statusConfigMap[type],
-        url,
-      },
-    ];
-  }
-
-  statusConfigs = statusConfigs.filter((x) => x.status != null);
+  const statusConfigs = getStatusConfigs({
+    tags,
+    parameters,
+    // No need to pass customConfigs here as within a story, parameters.statuses
+    // already includes the custom statuses defined in preview.js.
+  });
 
   if (!statusConfigs?.length) {
     return null;

--- a/src/getStatusConfigs.js
+++ b/src/getStatusConfigs.js
@@ -1,0 +1,87 @@
+import { defaultStatuses } from './defaults';
+
+const combineTagsAndParameters = (tags, parameters) => {
+  // If there are no parameter statuses, we only use the tags.
+  if (!parameters) {
+    return tags ?? [];
+  }
+
+  // If parameters is an array, there are multiple statuses.
+  if (Array.isArray(parameters)) {
+    return [...tags, ...parameters];
+  }
+
+  // If parameters is a string or an object, it's a single status.
+  if (typeof parameters === 'string' || typeof parameters === 'object') {
+    return [...tags, parameters];
+  }
+
+  // We shouldn't get here but if we do, return an empty array.
+  return [];
+};
+
+const filterStatuses = (statuses) => {
+  const filteredStatuses = [];
+  const existingNames = [];
+
+  statuses.forEach((status) => {
+    const name = typeof status === 'string' ? status : status.name;
+    if (!existingNames.includes(name)) {
+      filteredStatuses.push(status);
+      existingNames.push(name);
+      return;
+    }
+    // If the same status is defined in both tags and parameters, it should only be included once -
+    // parameter statuses override tag statuses as they may contain additional information.
+    if (status.name) {
+      const index = existingNames.indexOf(name);
+      if (index !== -1) {
+        filteredStatuses[index] = status;
+      }
+    }
+  });
+
+  return filteredStatuses;
+};
+
+export const getStatusConfigs = ({ tags, parameters, customConfigs }) => {
+  // If there are no statuses from either parameters or tags, return an empty array.
+  if (!parameters && !tags?.length) {
+    return [];
+  }
+
+  // Combine the tag and parameter statuses into a single array.
+  const combinedStatuses = combineTagsAndParameters(tags, parameters?.type);
+
+  // Filter out duplicate statuses based on their names.
+  const statuses = filterStatuses(combinedStatuses);
+
+  // Combine the default and custom status configs.
+  // If there's no custom configs, try to use the status configs from parameters.
+  const statusConfigMap = {
+    ...defaultStatuses,
+    ...(customConfigs || parameters?.statuses || {}),
+  };
+
+  // Map the status names to their configurations.
+  let statusConfigs = statuses.map((status) => {
+    if (typeof status === 'string') {
+      return {
+        label: status,
+        status: statusConfigMap[status],
+        url: parameters?.url,
+      };
+    }
+
+    return {
+      label: status.name,
+      status: statusConfigMap[status.name],
+      url: status.url,
+    };
+  });
+
+  // Remove any missing status configurations
+  statusConfigs = statusConfigs.filter((x) => x.status != null);
+
+  return statusConfigs;
+};

--- a/src/manager.jsx
+++ b/src/manager.jsx
@@ -23,6 +23,11 @@ addons.register(ADDON_ID, (api) => {
         const isLeaf = ['root', 'group', 'story'].includes(item.type);
 
         try {
+          const sidebarDotsConfig = statusAddonConfig?.sidebarDots;
+          if (sidebarDotsConfig === 'none') {
+            return name;
+          }
+
           const parameters = api.getParameters(item.id, ADDON_ID);
 
           // item can be a Root | Group | Story
@@ -39,7 +44,7 @@ addons.register(ADDON_ID, (api) => {
             statusAddonConfig?.statuses ||
             api.getCurrentStoryData().parameters?.status?.statuses;
 
-          const statusConfigs = getStatusConfigs({
+          let statusConfigs = getStatusConfigs({
             tags,
             parameters,
             customConfigs,
@@ -47,6 +52,10 @@ addons.register(ADDON_ID, (api) => {
 
           if (statusConfigs.length === 0) {
             return name;
+          }
+
+          if (sidebarDotsConfig !== 'multiple') {
+            statusConfigs = [statusConfigs[0]];
           }
 
           return (

--- a/src/manager.jsx
+++ b/src/manager.jsx
@@ -14,6 +14,8 @@ addons.register(ADDON_ID, (api) => {
     render: () => <StatusTag />,
   });
 
+  const statusAddonConfig = addons.getConfig()?.[ADDON_ID] || {};
+
   addons.setConfig({
     sidebar: {
       renderLabel: (item) => {
@@ -34,6 +36,7 @@ addons.register(ADDON_ID, (api) => {
           // when viewing that story. This is a storybook limitation:
           // https://github.com/storybookjs/storybook/discussions/24022
           const customConfigs =
+            statusAddonConfig?.statuses ||
             api.getCurrentStoryData().parameters?.status?.statuses;
 
           const statusConfigs = getStatusConfigs({

--- a/src/manager.jsx
+++ b/src/manager.jsx
@@ -36,7 +36,7 @@ addons.register(ADDON_ID, (api) => {
           }
 
           // Get custom status configurations from the current story's parameters.
-          // This will include any custom statuses defined in preview.js or story parameters.
+          // This will include any custom statuses defined in manager.js, preview.js or story parameters.
           // However custom statuses from story parameters will only be available in the sidebar
           // when viewing that story. This is a storybook limitation:
           // https://github.com/storybookjs/storybook/discussions/24022

--- a/src/manager.jsx
+++ b/src/manager.jsx
@@ -42,25 +42,28 @@ addons.register(ADDON_ID, (api) => {
             customConfigs,
           });
 
-          const statusConfig = statusConfigs?.[0];
-
-          if (!statusConfig) {
+          if (statusConfigs.length === 0) {
             return name;
           }
-
-          const {
-            label: statusName,
-            status: { background, description },
-          } = statusConfig;
 
           return (
             <>
               {name}
-              <StatusDot
-                type={statusName}
-                background={background}
-                title={`${startCase(statusName)}: ${description}`}
-              />
+              {statusConfigs.map((statusConfig) => {
+                const {
+                  label: statusName,
+                  status: { background, description },
+                } = statusConfig;
+
+                return (
+                  <StatusDot
+                    key={statusName}
+                    type={statusName}
+                    background={background}
+                    title={`${startCase(statusName)}: ${description}`}
+                  />
+                );
+              })}
             </>
           );
         } catch (error) {

--- a/src/manager.jsx
+++ b/src/manager.jsx
@@ -5,7 +5,7 @@ import { addons, types } from 'storybook/manager-api';
 import StatusDot from './components/StatusDot';
 import StatusTag from './components/StatusTag';
 import { ADDON_ID } from './constants';
-import { defaultStatuses } from './defaults';
+import { getStatusConfigs } from './getStatusConfigs';
 
 addons.register(ADDON_ID, (api) => {
   addons.add(ADDON_ID, {
@@ -17,39 +17,41 @@ addons.register(ADDON_ID, (api) => {
   addons.setConfig({
     sidebar: {
       renderLabel: (item) => {
-        const { name } = item;
+        const { name, tags } = item;
         const isLeaf = ['root', 'group', 'story'].includes(item.type);
 
         try {
-          const status = api.getParameters(item.id, ADDON_ID);
+          const parameters = api.getParameters(item.id, ADDON_ID);
 
           // item can be a Root | Group | Story
-          if (!isLeaf || !status?.type) {
+          if (!isLeaf || (tags.length === 0 && !parameters?.type)) {
             return name;
           }
 
-          const statusConfigMap = {
-            ...defaultStatuses,
-            ...(status.statuses || {}),
-          };
+          // Get custom status configurations from the current story's parameters.
+          // This will include any custom statuses defined in preview.js or story parameters.
+          // However custom statuses from story parameters will only be available in the sidebar
+          // when viewing that story. This is a storybook limitation:
+          // https://github.com/storybookjs/storybook/discussions/24022
+          const customConfigs =
+            api.getCurrentStoryData().parameters?.status?.statuses;
 
-          let statusName = '';
+          const statusConfigs = getStatusConfigs({
+            tags,
+            parameters,
+            customConfigs,
+          });
 
-          if (Array.isArray(status.type)) {
-            const firstStatus = status.type?.[0];
-            statusName =
-              typeof firstStatus === 'string' ? firstStatus : firstStatus.name;
-          } else {
-            statusName = status.type;
-          }
-
-          const statusConfig = statusConfigMap[statusName];
+          const statusConfig = statusConfigs?.[0];
 
           if (!statusConfig) {
             return name;
           }
 
-          const { background, description } = statusConfig;
+          const {
+            label: statusName,
+            status: { background, description },
+          } = statusConfig;
 
           return (
             <>

--- a/stories/Button.stories.jsx
+++ b/stories/Button.stories.jsx
@@ -8,19 +8,16 @@ export default {
   argTypes: {
     backgroundColor: { control: 'color' },
   },
+  tags: ['beta', 'customStatus'],
   parameters: {
     status: {
-      type: [
-        'beta',
-        {
-          name: 'customStatus',
-          url: 'http://www.url.com/custom',
-        },
-      ],
-      url: 'http://www.url.com/beta',
+      type: {
+        name: 'customStatus',
+        url: 'http://www.url.com/custom',
+      },
+      url: 'http://www.url.com/status',
     },
   },
-  tags: ['beta', 'customStatus'],
 };
 
 const Template = (args) => <Button {...args} />;

--- a/stories/Button.stories.jsx
+++ b/stories/Button.stories.jsx
@@ -10,10 +10,17 @@ export default {
   },
   parameters: {
     status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
+      type: [
+        'beta',
+        {
+          name: 'customStatus',
+          url: 'http://www.url.com/custom',
+        },
+      ],
+      url: 'http://www.url.com/beta',
     },
   },
+  tags: ['beta', 'customStatus'],
 };
 
 const Template = (args) => <Button {...args} />;

--- a/stories/Header.stories.jsx
+++ b/stories/Header.stories.jsx
@@ -5,11 +5,7 @@ import Header from './Header';
 export default {
   title: 'Example/Header',
   component: Header,
-  parameters: {
-    status: {
-      type: ['stable', 'releaseCandidate'],
-    },
-  },
+  tags: ['stable', 'releaseCandidate'],
 };
 
 const Template = (args) => <Header {...args} />;

--- a/stories/Page.stories.jsx
+++ b/stories/Page.stories.jsx
@@ -6,11 +6,7 @@ import Page from './Page';
 export default {
   title: 'Example/Page',
   component: Page,
-  parameters: {
-    status: {
-      type: 'customStatus',
-    },
-  },
+  tags: ['customStatus'],
 };
 
 const Template = (args) => <Page {...args} />;


### PR DESCRIPTION
Adds support for using storybook tags to set story statuses. 
- Simpler syntax in stories: `tags: ['beta', 'customStatus`]
- Supports filtering in the sidebar
- Sidebar dots appear for all stories, not just ones that have been viewed

The old way of setting statuses in story parameters is still fully supported, and both methods can be used together.

Config has moved from `preview.js` to `manager.js` to enable more features, but old configs in `preview.js` will still work.



