### PR TITLE
Install project deps before semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
+          cache: npm
+      - run: npm ci
       - uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90
         with:
           semantic_version: 25.0.1


### PR DESCRIPTION
The cycjimmy action only installs semantic-release into its own path, so the project's devDependencies (e.g. tsup) aren't available when npm publish runs the prepare lifecycle script. Add npm ci to install them, matching what the previous workflow did.